### PR TITLE
feat(usecase): read経路にspan statusを追加

### DIFF
--- a/internal/usecase/cookie_usecase.go
+++ b/internal/usecase/cookie_usecase.go
@@ -62,9 +62,39 @@ func (u *cookieUsecase) StoreCookies(ctx context.Context, cookies []*http.Cookie
 }
 
 func (u *cookieUsecase) GetAllCookies(ctx context.Context) ([]*entity.Cookie, error) {
-	return u.cookieRepo.FindAll(ctx)
+	tracer := otel.Tracer("cookiejar-server/usecase")
+	ctx, span := tracer.Start(ctx, "GetAllCookies", trace.WithSpanKind(trace.SpanKindInternal))
+	defer span.End()
+
+	cookies, err := u.cookieRepo.FindAll(ctx)
+	if err != nil {
+		log.Printf("Failed to get all cookies: %v", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "Failed to get all cookies")
+		return nil, err
+	}
+
+	span.SetAttributes(attribute.Int("cookie.count", len(cookies)))
+	span.SetStatus(codes.Ok, "Successfully retrieved all cookies")
+	return cookies, nil
 }
 
 func (u *cookieUsecase) GetCookiesByHost(ctx context.Context, host string) ([]*entity.Cookie, error) {
-	return u.cookieRepo.FindByHost(ctx, host)
+	tracer := otel.Tracer("cookiejar-server/usecase")
+	ctx, span := tracer.Start(ctx, "GetCookiesByHost", trace.WithSpanKind(trace.SpanKindInternal))
+	defer span.End()
+
+	span.SetAttributes(attribute.String("cookie.host", host))
+
+	cookies, err := u.cookieRepo.FindByHost(ctx, host)
+	if err != nil {
+		log.Printf("Failed to get cookies for host=%s: %v", host, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "Failed to get cookies by host")
+		return nil, err
+	}
+
+	span.SetAttributes(attribute.Int("cookie.count", len(cookies)))
+	span.SetStatus(codes.Ok, "Successfully retrieved cookies by host")
+	return cookies, nil
 }


### PR DESCRIPTION
## 概要

read経路の usecase メソッド (`GetAllCookies` / `GetCookiesByHost`) に OpenTelemetry span と `SetStatus` を追加しました。これまで span 自体がなく span status code が記録されていなかった read経路を、write経路 (`StoreCookies`) と同じパターンに揃えています。

これにより writer / reader 両サービスの全 span(startup・HTTPミドルウェア・handler・usecase の read/write 経路)で span status code が漏れなく設定されます。

## 変更内容

| メソッド | 使用元 | 変更後 |
|---|---|---|
| `GetCookiesByHost` | reader (gRPC `GetCookies`) | span作成 + `cookie.host`/`cookie.count`属性 + `SetStatus(Ok/Error)` |
| `GetAllCookies` | writer | span作成 + `cookie.count`属性 + `SetStatus(Ok/Error)` |

- 成功時: `span.SetStatus(codes.Ok, ...)`
- 失敗時: `span.RecordError(err)` + `span.SetStatus(codes.Error, ...)`

## テスト

- `go build ./...` 成功
- `go vet ./internal/usecase/` 成功
- `go test ./internal/usecase/` 成功