### PR TITLE
feat(reader): gRPCルートspanにstatusを設定

### DIFF
--- a/cmd/reader/main.go
+++ b/cmd/reader/main.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
@@ -33,10 +34,16 @@ type cookieServiceServer struct {
 }
 
 func (s *cookieServiceServer) GetCookies(ctx context.Context, req *pb.GetCookiesRequest) (*pb.GetCookiesResponse, error) {
+	// otelgrpc が生成したルート span を取得（成功時に明示的に Ok を立て、trace レベルが UNSET にならないようにする）
+	span := trace.SpanFromContext(ctx)
+
 	// hostでCookieを取得
 	cookies, err := s.container.CookieUsecase.GetCookiesByHost(ctx, req.Host)
 	if err != nil {
+		// otelgrpc は NotFound 等を span status Error にマップしないため、明示的に Error を立てる
 		log.Printf("Failed to get cookies for host %s: %v", req.Host, err)
+		span.RecordError(err)
+		span.SetStatus(otelcodes.Error, "Failed to get cookies")
 		return nil, status.Errorf(codes.NotFound, "cookies not found for host: %s", req.Host)
 	}
 
@@ -47,6 +54,7 @@ func (s *cookieServiceServer) GetCookies(ctx context.Context, req *pb.GetCookies
 		cookieStrings = append(cookieStrings, httpCookie.String())
 	}
 
+	span.SetStatus(otelcodes.Ok, "Successfully retrieved cookies")
 	return &pb.GetCookiesResponse{
 		Cookies: strings.Join(cookieStrings, "; "),
 	}, nil


### PR DESCRIPTION
## 背景

前回の変更 (#125) で usecase 層の read 経路に span status を追加したが、**trace 全体を代表するルート span(otelgrpc が生成する gRPC サーバー span)は依然 UNSET** だった。

OTel semantic convention 上、gRPC サーバー span は:
- 成功時: status を明示的に OK にしない(UNSET のまま)
- エラー時: `otelgrpc` は `Unknown/DeadlineExceeded/Unimplemented/Internal/Unavailable/DataLoss` のみ Error にマップ。**`NotFound` は Unset 扱い**

このため、span レベルでは Ok でも **trace レベルでは UNSET** に見える問題があった。

## 変更内容

`cmd/reader/main.go` の `GetCookies` で、otelgrpc が ctx に注入したルート span を取得し、明示的に status を設定する:

- 成功時: `span.SetStatus(otelcodes.Ok, ...)`
- エラー時: `span.RecordError(err)` + `span.SetStatus(otelcodes.Error, ...)`(NotFound でも trace レベルで Error になる)

OTel Go SDK は status code の昇順優先(Unset < Error < Ok)で更新するため、先に Error を立てれば otelgrpc が後続で行う Unset 設定には上書きされない。

writer は `middleware/otel.go` で既にルート span へ OK を明示設定済みのため対応不要。

## テスト

- `go build ./...` / `go vet ./cmd/reader/` / `gofmt` 成功
- `go test ./...` 成功