### PR TITLE
[codex] Remove Renovate auto-merge hooks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,16 +64,3 @@ jobs:
         if: always()
         run: docker compose down -v
 
-  automerge:
-    runs-on: ubuntu-latest
-    needs: [test, e2e]
-    if: github.event.pull_request.user.login == 'renovate[bot]'
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: automerge
-        uses: pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67 # v0.16.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MERGE_LABELS: ""

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,15 +6,9 @@
   minimumReleaseAge: "3 days",
   lockFileMaintenance: {
     minimumReleaseAge: null,
-    addLabels: [
-      "automerge"
-    ]
   },
   vulnerabilityAlerts: {
     minimumReleaseAge: null,
-    addLabels: [
-      "automerge"
-    ]
   },
   packageRules: [
     {
@@ -26,9 +20,6 @@
       ],
       groupName: "all minor, patch, and digest updates",
       groupSlug: "all-minor-patch-digest-updates",
-      addLabels: [
-        "automerge"
-      ]
     },
     {
       matchManagers: [


### PR DESCRIPTION
## Summary
- remove explicit CI jobs that merge Renovate pull requests
- stop adding the `automerge` label from Renovate config

## Validation
- inspected the resulting diff for the touched CI and Renovate config files
